### PR TITLE
fix: #2 Swift 6.0 concurrency errors

### DIFF
--- a/Sources/TemporalKit/Core/ClosureTemporalProposition.swift
+++ b/Sources/TemporalKit/Core/ClosureTemporalProposition.swift
@@ -6,12 +6,12 @@ import Foundation
 /// making it convenient for simpler propositions without needing to create a separate subclass.
 /// It is generic over the `StateType` it expects from the `EvaluationContext` and the
 /// `PropositionResultType` that the evaluation yields.
-open class ClosureTemporalProposition<StateType, PropositionResultType: Hashable>: TemporalProposition {
+open class ClosureTemporalProposition<StateType, PropositionResultType: Hashable>: TemporalProposition, @unchecked Sendable {
     public typealias Value = PropositionResultType
 
     public let id: PropositionID
     public let name: String
-    private let evaluationLogic: (StateType) throws -> PropositionResultType
+    private let evaluationLogic: @Sendable (StateType) throws -> PropositionResultType
 
     /// Initializes a new closure-based temporal proposition.
     ///
@@ -20,7 +20,7 @@ open class ClosureTemporalProposition<StateType, PropositionResultType: Hashable
     ///   - name: The human-readable name of the proposition.
     ///   - evaluate: A closure that takes an object of `StateType` and returns the `PropositionResultType`.
     ///               This closure can throw errors.
-    public init(id: String, name: String, evaluate: @escaping (StateType) throws -> PropositionResultType) {
+    public init(id: String, name: String, evaluate: @escaping @Sendable (StateType) throws -> PropositionResultType) {
         // Use failable initializer and provide fallback for invalid IDs
         self.id = PropositionID(rawValue: id) ?? PropositionID(rawValue: "invalid_id")!
         self.name = name
@@ -67,7 +67,7 @@ open class ClosureTemporalProposition<StateType, PropositionResultType: Hashable
     public static func nonThrowing(
         id: String,
         name: String,
-        evaluate: @escaping (StateType) -> PropositionResultType
+        evaluate: @escaping @Sendable (StateType) -> PropositionResultType
     ) -> ClosureTemporalProposition<StateType, PropositionResultType> {
         ClosureTemporalProposition(
             id: id,

--- a/Sources/TemporalKit/Core/PropositionFactories.swift
+++ b/Sources/TemporalKit/Core/PropositionFactories.swift
@@ -14,7 +14,7 @@ import Foundation
 public func makeProposition<StateType, PropositionResultType: Hashable>(
     id: String,
     name: String,
-    evaluate: @escaping (StateType) -> PropositionResultType
+    evaluate: @escaping @Sendable (StateType) -> PropositionResultType
 ) -> ClosureTemporalProposition<StateType, PropositionResultType> {
     // Internally, it calls the static 'nonThrowing' factory method we already defined.
     ClosureTemporalProposition<StateType, PropositionResultType>.nonThrowing(

--- a/Sources/TemporalKit/DSL/LTLFormula+Validation.swift
+++ b/Sources/TemporalKit/DSL/LTLFormula+Validation.swift
@@ -526,7 +526,7 @@ extension LTLFormula {
 // MARK: - Validation Configuration
 
 /// Configuration for formula validation.
-public struct ValidationConfiguration {
+public struct ValidationConfiguration: Sendable {
     /// The level of validation to perform.
     public let level: ValidationLevel
 
@@ -558,7 +558,7 @@ public struct ValidationConfiguration {
 }
 
 /// Levels of validation thoroughness.
-public enum ValidationLevel {
+public enum ValidationLevel: Sendable {
     /// Basic validation for obvious issues.
     case basic
 

--- a/Sources/TemporalKit/Errors/ModelCheckingError.swift
+++ b/Sources/TemporalKit/Errors/ModelCheckingError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// モデルチェッキング処理中に発生するエラー
-public enum ModelCheckingError<State>: Error, LocalizedError {
+public enum ModelCheckingError<State: Sendable>: Error, LocalizedError {
     /// 無効なKripke構造
     case invalidKripkeStructure(reason: String)
 
@@ -60,7 +60,7 @@ public enum ModelCheckingError<State>: Error, LocalizedError {
 }
 
 /// モデルチェッキングの統計情報
-public struct ModelCheckingStatistics {
+public struct ModelCheckingStatistics: Sendable {
     public let statesExplored: Int
     public let transitionsExplored: Int
     public let timeElapsed: TimeInterval

--- a/Sources/TemporalKit/Errors/TemporalKitError.swift
+++ b/Sources/TemporalKit/Errors/TemporalKitError.swift
@@ -4,7 +4,7 @@ public enum TemporalKitError: Error, LocalizedError {
     case stateTypeMismatch(expected: String, actual: String, propositionID: PropositionID, propositionName: String)
     case stateNotAvailable(expected: String, propositionID: PropositionID, propositionName: String)
     case configurationError(message: String)
-    case invalidArgument(parameter: String, value: Any?, reason: String)
+    case invalidArgument(parameter: String, value: String?, reason: String)
     case unsupportedOperation(operation: String, reason: String)
 
     public var errorDescription: String? {


### PR DESCRIPTION
## Summary
- Fixed Swift 6.0 strict concurrency checking errors that were preventing CI builds from succeeding
- Made all necessary types conform to `Sendable` protocol as required by Swift 6.0
- Resolved type safety issues with `Any?` parameter in error types

## Changes
1. **ValidationConfiguration & ValidationLevel**: Added `Sendable` conformance to fix static property warnings
2. **ModelCheckingError**: Added `Sendable` constraint to generic `State` parameter
3. **TemporalKitError**: Changed `invalidArgument` case to use `String?` instead of `Any?` for Sendable compliance
4. **ClosureTemporalProposition**: Marked as `@unchecked Sendable` and updated closures to use `@Sendable` annotation
5. **ModelCheckingStatistics**: Added `Sendable` conformance

## Test Plan
- [x] Verified that `swift build --target TemporalKit` succeeds without concurrency errors
- [ ] CI builds should now pass without Swift 6.0 concurrency errors
- [ ] Tests may still have issues with capturing `self` in Sendable closures (separate issue)

## Related
- Fixes #2 
- Related to PR #1 (Add GitHub Actions CI workflow)

🤖 Generated with [Claude Code](https://claude.ai/code)