### PR TITLE
fix: GBA 構築の状態数上限超過時にエラーを throw する (#20)

### DIFF
--- a/Sources/TemporalKit/ModelChecking/Algorithms/LTLToBuchiConverter.swift
+++ b/Sources/TemporalKit/ModelChecking/Algorithms/LTLToBuchiConverter.swift
@@ -41,7 +41,7 @@ internal enum LTLToBuchiConverter {
             originalPreNNFFormula: ltlFormula,
             relevantPropositions: relevantPropositions
         )
-        tableauConstructor.buildGraph()
+        try tableauConstructor.buildGraph()
 
         let constructedTableauNodes = tableauConstructor.constructedTableauNodes
         let nodeToGBAStateIDMap = tableauConstructor.gbaStateIDMap

--- a/Sources/TemporalKit/ModelChecking/Algorithms/TableauGraphConstructor.swift
+++ b/Sources/TemporalKit/ModelChecking/Algorithms/TableauGraphConstructor.swift
@@ -71,7 +71,9 @@ internal class TableauGraphConstructor<P: TemporalProposition, PropositionIDType
     }
 
     /// Builds the tableau graph, populating GBA states, transitions, and initial states.
-    internal func buildGraph() {
+    internal func buildGraph() throws {
+        /// Guard against runaway tableau construction for formulas with exponential state spaces.
+        let maxGBAStateCount = 150
         let initialTableauNode = Self.decomposeFormulaForInitialTableauNode(self.nnfLTLFormula)
         self.worklist = [initialTableauNode]
         _ = getOrCreateGBAStateID(for: initialTableauNode)
@@ -93,37 +95,6 @@ internal class TableauGraphConstructor<P: TemporalProposition, PropositionIDType
                     heuristicOriginalLTLFormula: self.originalPreNNFLTLFormula
                 )
 
-                // ---- DEBUG for X(¬q) specific expansion ----
-                var isXNotQContext = false
-                if case .next(let sub) = self.originalPreNNFLTLFormula,
-                   case .not(let nSub) = sub,
-                   case .atomic(let a) = nSub,
-                   String(describing: a.id) == "q" {
-                    isXNotQContext = true
-                }
-
-                var currentNodeContainsNotQ = false
-                for f in currentNodeToExpand.currentFormulas {
-                    if case .not(let subF) = f, case .atomic(let atomF) = subF, String(describing: atomF.id) == "q" {
-                        currentNodeContainsNotQ = true
-                        break
-                    }
-                }
-                let symbolContainsQ = symbol.contains(where: { String(describing: $0).contains("q") })
-
-                if isXNotQContext && currentNodeContainsNotQ && symbolContainsQ {
-                    let currentFormulaDescs = currentNodeToExpand.currentFormulas.map { String(describing: $0).prefix(20) }
-                    let nextFormulaDescs = currentNodeToExpand.nextFormulas.map { String(describing: $0).prefix(20) }
-                    print("[TGC BUILDGRAPH DEBUG XNOTQ] For node (current: \(currentFormulaDescs), next: \(nextFormulaDescs)) with symbol \(symbol):")
-                    print("    expandFormulasInNode produced \(expansionResults.count) outcomes:")
-                    for (idx, outcome) in expansionResults.enumerated() {
-                        let currObligations = outcome.nextSetOfCurrentObligations.map { String(describing: $0).prefix(20) }
-                        let nextObligations = outcome.nextSetOfNextObligations.map { String(describing: $0).prefix(20) }
-                        print("      Outcome \(idx): consistent=\(outcome.isConsistent), currO=\(currObligations), nextO=\(nextObligations) ")
-                    }
-                }
-                // ---- END DEBUG ----
-
                 for expansionResult in expansionResults {
                     if !expansionResult.isConsistent { continue }
 
@@ -140,15 +111,13 @@ internal class TableauGraphConstructor<P: TemporalProposition, PropositionIDType
                         worklist.append(successorNode)
                     }
 
-                    if nodeToStateIDMap.count > 150 {
-                        print("Warning: Max GBA states (150) reached in tableau. Aborting expansion.")
-                        self.worklist.removeAll()
-                        break
+                    if nodeToStateIDMap.count > maxGBAStateCount {
+                        throw LTLModelCheckerError.internalProcessingError(
+                            "GBA state limit (\(maxGBAStateCount)) exceeded during tableau construction; result may be unsound"
+                        )
                     }
                 }
-                if nodeToStateIDMap.count > 150 { break }
             }
-            if nodeToStateIDMap.count > 150 { break }
         }
     }
 

--- a/Tests/TemporalKitTests/LTLToBuchiConverterTests.swift
+++ b/Tests/TemporalKitTests/LTLToBuchiConverterTests.swift
@@ -141,14 +141,16 @@ struct LTLToBuchiConverterTests {
         let eventuallyFormulas: [Formula] = (1...8).map { .eventually(.not(.prop("limit_p\($0)"))) }
         let formula: Formula = eventuallyFormulas.dropFirst().reduce(eventuallyFormulas[0]) { .and($0, $1) }
 
-        #expect {
+        // Note: assert via do/catch rather than `#expect { } throws: { #expect(...) }`.
+        // A nested `#expect` inside the `throws:` matcher crashes the Swift 6.0 Linux
+        // type-checker (signal 11); do/catch pins the same case + message portably.
+        do {
             _ = try LTLToBuchiConverter.translateLTLToBuchi(formula, relevantPropositions: propIDs)
-        } throws: { error in
-            guard case let LTLModelCheckerError.internalProcessingError(message) = error else {
-                return false
-            }
+            Issue.record("Expected LTLModelCheckerError.internalProcessingError to be thrown for >150 GBA states")
+        } catch let LTLModelCheckerError.internalProcessingError(message) {
             #expect(message.contains("GBA state limit"))
-            return true
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
         }
     }
 }

--- a/Tests/TemporalKitTests/LTLToBuchiConverterTests.swift
+++ b/Tests/TemporalKitTests/LTLToBuchiConverterTests.swift
@@ -141,8 +141,14 @@ struct LTLToBuchiConverterTests {
         let eventuallyFormulas: [Formula] = (1...8).map { .eventually(.not(.prop("limit_p\($0)"))) }
         let formula: Formula = eventuallyFormulas.dropFirst().reduce(eventuallyFormulas[0]) { .and($0, $1) }
 
-        #expect(throws: LTLModelCheckerError.self) {
+        #expect {
             _ = try LTLToBuchiConverter.translateLTLToBuchi(formula, relevantPropositions: propIDs)
+        } throws: { error in
+            guard case let LTLModelCheckerError.internalProcessingError(message) = error else {
+                return false
+            }
+            #expect(message.contains("GBA state limit"))
+            return true
         }
     }
 }

--- a/Tests/TemporalKitTests/LTLToBuchiConverterTests.swift
+++ b/Tests/TemporalKitTests/LTLToBuchiConverterTests.swift
@@ -130,6 +130,21 @@ struct LTLToBuchiConverterTests {
             Issue.record("Initial state was nil, cannot check if it's accepting.")
         }
     }
+    /// Verifies that buildGraph() throws when the GBA state count exceeds maxGBAStateCount (150).
+    ///
+    /// F(¬p1) ∧ F(¬p2) ∧ ... ∧ F(¬p8) has up to 2^8 = 256 GBA states because each
+    /// Eventually obligation can independently be pending or discharged. This exceeds the
+    /// 150-state guard and must throw LTLModelCheckerError.internalProcessingError.
+    @Test func buildGraphThrowsWhenGBAStateLimitExceeded() {
+        let propIDs = Set((1...8).map { PropositionID(rawValue: "limit_p\($0)")! })
+        // F(¬p1) ∧ F(¬p2) ∧ ... ∧ F(¬p8)
+        let eventuallyFormulas: [Formula] = (1...8).map { .eventually(.not(.prop("limit_p\($0)"))) }
+        let formula: Formula = eventuallyFormulas.dropFirst().reduce(eventuallyFormulas[0]) { .and($0, $1) }
+
+        #expect(throws: LTLModelCheckerError.self) {
+            _ = try LTLToBuchiConverter.translateLTLToBuchi(formula, relevantPropositions: propIDs)
+        }
+    }
 }
 
 // Note: More complex assertions will require comparing the generated automaton's language

--- a/Tests/TemporalKitTests/PerformanceTests.swift
+++ b/Tests/TemporalKitTests/PerformanceTests.swift
@@ -176,7 +176,7 @@ final class PerformanceTests: XCTestCase {
         GBAConditionGenerator<TestProposition>()
     }
 
-    func testGBAGeneration_Performance_SimpleFormula() {
+    func testGBAGeneration_Performance_SimpleFormula() throws {
         let p = makeProposition("p")
         let formula: LTLFormula<TestProposition> = .globally(.atomic(p))
         let nnfFormula = LTLFormulaNNFConverter.convert(formula) // Convert to NNF
@@ -186,7 +186,7 @@ final class PerformanceTests: XCTestCase {
             originalPreNNFFormula: formula,
             relevantPropositions: Set([p.id])
         )
-        constructor.buildGraph()
+        try constructor.buildGraph()
         let tableauNodes = constructor.constructedTableauNodes
         let nodeMap = constructor.gbaStateIDMap
 
@@ -201,7 +201,7 @@ final class PerformanceTests: XCTestCase {
         }
     }
 
-    func testGBAGeneration_Performance_MediumFormula() {
+    func testGBAGeneration_Performance_MediumFormula() throws {
         let p = makeProposition("p")
         let q = makeProposition("q")
         let formula: LTLFormula<TestProposition> = .globally(
@@ -217,7 +217,7 @@ final class PerformanceTests: XCTestCase {
             originalPreNNFFormula: formula,
             relevantPropositions: Set([p.id, q.id])
         )
-        constructor.buildGraph()
+        try constructor.buildGraph()
         let tableauNodes = constructor.constructedTableauNodes
         let nodeMap = constructor.gbaStateIDMap
 
@@ -232,7 +232,7 @@ final class PerformanceTests: XCTestCase {
         }
     }
 
-    func testGBAGeneration_Performance_ComplexFormula() {
+    func testGBAGeneration_Performance_ComplexFormula() throws {
         let p = makeProposition("p")
         let q = makeProposition("q")
         let r = makeProposition("r")
@@ -255,7 +255,7 @@ final class PerformanceTests: XCTestCase {
             originalPreNNFFormula: formula,
             relevantPropositions: Set([p.id, q.id, r.id, s.id])
         )
-        constructor.buildGraph()
+        try constructor.buildGraph()
         let tableauNodes = constructor.constructedTableauNodes
         let nodeMap = constructor.gbaStateIDMap
 


### PR DESCRIPTION
## 概要
GBA 構築の状態数上限（150）超過時の**サイレント打ち切り**による健全性の穴（#20）を修正します。打ち切ると不完全な式オートマトンのまま判定が進み、本来 FAILS の式が誤って HOLDS になり得ました。

## 修正内容
- `TableauGraphConstructor.buildGraph()` を `throws` 化し、状態数が `maxGBAStateCount`（150）を超えたら `LTLModelCheckerError.internalProcessingError` を **throw**（サイレント打ち切りを廃止）。
- `print` / `worklist.removeAll()` / 重複した上限チェックを撤去。
- 呼び出し側 `LTLToBuchiConverter.translateLTLToBuchi` を `try` 伝播（`LTLModelChecker.check` まで伝播）。
- 付随: `buildGraph()` 内に残存していた dead な XNOTQ デバッグブロック（命題名 "q" の文字列マッチ）を除去（#23 の一部）。

## テスト
- 追加: `buildGraphThrowsWhenGBAStateLimitExceeded` — `F(¬p1)∧…∧F(¬p8)`（2^8=256 状態）で `LTLModelCheckerError` が throw されることを検証。
- `PerformanceTests` の GBA 生成3テストを `throws`/`try` 対応。

## 検証
- ✅ `swift build` 成功
- ✅ `swift test` — **264 tests / 31 suites 全 pass**（新規 throw テスト含む）

## 関連 Issue
Closes #20

## 備考
実装は Codex (GPT) に委譲、Claude Code が仕様提示・差分検証を担当。スコープは throw 化のみ（閾値の引き上げ・設定可能化は含めず）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 複雑な条件での変換処理が、テーブル生成中の状態数上限を超えた場合に、警告のまま中断せずエラーとして停止するようになりました。
  * 生成失敗に伴う例外が呼び出し元へ確実に伝わるようになり、失敗検知が強化されました。
* **Tests**
  * 状態数上限超過時にエラーとなることを確認するテストを追加しました。
  * 生成パフォーマンステストを、例外に対応する形へ更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->