### PR TITLE
chore: MIT LICENSE 追加・macOS CI ジョブ追加・Package.swift プラットフォーム整理 (#25, #26)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,23 @@ jobs:
       run: swift test -v
 
 
+  test-macos:
+    name: Test on macOS
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Show Swift version
+      run: swift --version
+
+    - name: Build
+      run: swift build -v
+
+    - name: Run tests
+      run: swift test -v
+
+
   lint:
     name: SwiftLint
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,13 @@ jobs:
   test-macos:
     name: Test on macOS
     runs-on: macos-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Show Swift version
       run: swift --version

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 CAPHTECH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 CAPHTECH
+Copyright (c) 2025 CAPH TECH Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "TemporalKit",
     platforms: [
-        .macOS(.v10_15), // Example platform, adjust as needed
-        .iOS(.v13),      // Example platform, adjust as needed
+        .macOS(.v10_15),
+        .iOS(.v13),
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.


### PR DESCRIPTION
## 概要
リリース体裁の2件をまとめて対応します。

## #25 LICENSE ファイル追加
README / Package が MIT を名乗るが、リポジトリに `LICENSE` ファイルが存在しなかった問題を解消。MIT ライセンス全文を追加しました。
- **著作権者は `CAPHTECH`・年は `2026`** としています。法的に正確な表記（法人格表記や `Ryoichi Izumita`、開始年など）に調整が必要なら指摘してください。

## #26 Apple プラットフォーム CI
- `ci.yml` に **`macos-latest` での `swift build` / `swift test`（Test on macOS）** ジョブを追加。従来は Linux（`swift:6.0` コンテナ）のみで、Apple ツールチェーン固有の回帰を検出できませんでした。
- `Package.swift` の `// Example platform, adjust as needed` プレースホルダコメントを除去し、対象プラットフォーム（iOS 13 / macOS 10.15）を確定。

## 検証
- ✅ `ci.yml` YAML 妥当（jobs: test-linux, test-macos, lint, build-docs, performance-test）
- ✅ `swift build` 成功（Package.swift コメント除去後）
- macOS ジョブの実挙動は本 PR の CI（Test on macOS）で検証されます。

## 関連 Issue
Closes #25
Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS環境でのビルドとテストを含む新しいCIジョブが追加されました。
* **Documentation**
  * ライセンス情報がMIT Licenseに更新されました。
* **Chores**
  * プラットフォーム設定のコメントが整理され、記述が簡潔になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->