### PR TITLE
docs: テスト記述支援スキル skills/temporalkit-tests を追加

### DIFF
--- a/skills/temporalkit-tests/SKILL.md
+++ b/skills/temporalkit-tests/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: temporalkit-tests
+description: >-
+  Write tests for the TemporalKit LTL library WITHOUT reading the source first.
+  Hands over the library-specific facts the bare model gets wrong from memory:
+  the exact normalized()/NNF rewrite forms, PropositionID/proposition
+  construction, the per-directory test framework, and the model-checking setup.
+  Use when adding or editing tests under Tests/TemporalKitTests for LTLFormula,
+  normalized(), LTLModelChecker / KripkeStructure, trace evaluation, or the DSL.
+---
+
+# Writing TemporalKit tests
+
+This skill exists so you can write **correct, compiling, passing** TemporalKit
+tests fast, from the facts below, without grepping `Sources/`. It encodes only
+the things a from-memory attempt measurably gets wrong (verified by running):
+the `normalized()` rewrite forms, `PropositionID` construction, and the
+framework-per-directory rule. Everything else (enum case names, `check`
+signature, counterexample shape) the model already gets right — don't overthink it.
+
+Full signatures and the complete rewrite table: **[references/api-and-semantics.md](references/api-and-semantics.md).** Read it before asserting any `normalized()` output.
+
+## Required output structure
+
+A TemporalKit test file must have, in order:
+
+1. **Correct framework import for the directory it lives in** (see rule below).
+2. A **concrete proposition type** — almost always
+   `ClosureTemporalProposition<State, Bool>` built via
+   `TemporalKit.makeProposition(id: "p", name: "p") { (_: State) in true }`.
+   `id:` is a **`String`**, not a `PropositionID`.
+3. **Exact expected values** for any `normalized()` assertion, taken from the
+   rewrite table — not from textbook LTL duality.
+4. For model-checking: a `KripkeStructure` whose `atomicPropositionsTrue(in:)`
+   returns `Set<PropositionID>` built from **`prop.id`** (never a string literal),
+   and `typealias AtomicPropositionIdentifier = PropositionID`.
+
+## The three things to get right (each with both failure modes)
+
+### 1. Framework: match the directory, don't globally pick one
+- Tests under `ModelChecking/` (and `PerformanceTests`) use **XCTest**
+  (`import XCTest`, `final class … : XCTestCase`, `XCTAssertEqual`, `func test…() throws`).
+- Everything else — `Core/`, `Formulas/`, `Evaluation/`, `DSL/`, `Errors/` — uses
+  **swift-testing** (`import Testing`, `struct`, `@Test`, `#expect`).
+- Failure modes to avoid: (a) defaulting the whole repo to XCTest — a
+  `normalized()` test belongs in the swift-testing world; (b) imposing
+  swift-testing when *extending an existing XCTest file* — match the file you edit.
+
+### 2. `normalized()`: use TemporalKit's forms, not standard duality
+The single biggest from-memory error. TemporalKit's negated-temporal rewrites are
+**not** the textbook `¬(A U B) ≡ ¬A R ¬B`. The actual forms (full table in the
+reference):
+- `¬(A U B)` → `(¬A ∧ ¬B) R ¬B`   (NOT `¬A R ¬B`)
+- `¬(A R B)` → `¬B U (¬A ∧ ¬B)`   (NOT `¬A U ¬B`)
+- `¬(A W B)` → `¬B U (¬A ∧ ¬B)`
+- Constant collapses are specific too, e.g. `A W false` → `G A`, `false R B` → `G B`.
+
+Don't over-claim simplification either: `normalized()` is NNF + the listed
+boolean/temporal-constant rules and `F F`/`G G` idempotency — it does **not**
+distribute, flatten associativity, or simplify across unrelated subformulas.
+If unsure of a form, assert a structural property (e.g. "contains no `.implies`",
+or idempotency `f.normalized() == f.normalized().normalized()`) instead of guessing.
+
+### 3. `PropositionID` is `RawRepresentable`, not string-literal
+- Build with `PropositionID(rawValue: "p")!` (failable init) when you need one
+  directly; but prefer `prop.id`.
+- `Set<PropositionID>` literals like `["p"]` **do not compile** (no
+  `ExpressibleByStringLiteral`). In a labeling function return `[prop.id]`.
+- `makeProposition(id:name:evaluate:)` takes `id:` as a **`String`** — pass `"p"`,
+  not `PropositionID(...)`.
+
+## Linux CI gate
+Linux CI pins **Swift 6.0** (macOS uses latest). Avoid 6.1+-only syntax: no
+trailing commas in argument/collection lists, no `#expect` nested inside a
+`throws:` closure. (Same constraint recorded in session memory.)

--- a/skills/temporalkit-tests/references/api-and-semantics.md
+++ b/skills/temporalkit-tests/references/api-and-semantics.md
@@ -1,0 +1,154 @@
+# TemporalKit test-author reference
+
+Exact, source-derived facts for writing tests without reopening `Sources/`.
+All `swift-testing`/`XCTest` examples are interchangeable; pick per the
+directory rule in SKILL.md.
+
+## Core types
+
+```swift
+// Sources/TemporalKit/Core/LTLFormula.swift
+public indirect enum LTLFormula<P: TemporalProposition>: Hashable where P.Value == Bool {
+    case booleanLiteral(Bool)
+    case atomic(P)
+    case not(LTLFormula<P>)
+    case and(LTLFormula<P>, LTLFormula<P>)
+    case or(LTLFormula<P>, LTLFormula<P>)
+    case implies(LTLFormula<P>, LTLFormula<P>)
+    case next(LTLFormula<P>)
+    case eventually(LTLFormula<P>)
+    case globally(LTLFormula<P>)
+    case until(LTLFormula<P>, LTLFormula<P>)
+    case weakUntil(LTLFormula<P>, LTLFormula<P>)
+    case release(LTLFormula<P>, LTLFormula<P>)
+}
+// Equality is STRUCTURAL. Two `.atomic` are equal iff their propositions are
+// equal, and proposition equality is by `id` only — the evaluate closure is
+// irrelevant to equality.
+```
+
+```swift
+// TemporalProposition: AnyObject, Hashable, Identifiable
+//   var id: PropositionID ; var name: String
+//   func evaluate(in context: EvaluationContext) throws -> Value   (Value == Bool here)
+
+// PropositionID: Hashable, Equatable, RawRepresentable, Codable, Sendable
+//   init?(rawValue: String)          // FAILABLE — use `!` in tests: PropositionID(rawValue: "p")!
+//   init(validating: String) throws
+// NOT ExpressibleByStringLiteral → `let s: Set<PropositionID> = ["p"]` does NOT compile.
+
+// Build propositions with the factory (note: id is a String):
+public func makeProposition<S, R: Hashable>(
+    id: String, name: String, evaluate: @escaping @Sendable (S) -> R
+) -> ClosureTemporalProposition<S, R>
+// e.g. let p = TemporalKit.makeProposition(id: "p", name: "p") { (_: Int) in true }
+//   →  p has type ClosureTemporalProposition<Int, Bool>, p.id is PropositionID("p")
+```
+
+Typealiases that read well in a test file:
+```swift
+typealias Prop = ClosureTemporalProposition<Int, Bool>   // any Hashable State works
+typealias F = LTLFormula<Prop>
+```
+
+## `normalized()` — the exact rewrite table
+
+`normalized()` returns NNF via a fixed-point of three passes
+(eliminate implications → push negations inward → simplify constants). It applies
+ONLY the rules below; it does not distribute, reassociate, or simplify unrelated
+subformulas.
+
+**Implication**
+- `A → B`  ⇒  `¬A ∨ B`   (recursively, everywhere)
+
+**Negation push (De Morgan + dualities)**
+- `¬¬A` ⇒ `A`   ·   `¬true` ⇒ `false`   ·   `¬false` ⇒ `true`
+- `¬(A ∧ B)` ⇒ `¬A ∨ ¬B`   ·   `¬(A ∨ B)` ⇒ `¬A ∧ ¬B`
+- `¬X A` ⇒ `X ¬A`
+- `¬F A` ⇒ `G ¬A`   ·   `¬G A` ⇒ `F ¬A`
+- `¬(A U B)` ⇒ **`(¬A ∧ ¬B) R ¬B`**   ← not `¬A R ¬B`
+- `¬(A R B)` ⇒ **`¬B U (¬A ∧ ¬B)`**   ← not `¬A U ¬B`
+- `¬(A W B)` ⇒ **`¬B U (¬A ∧ ¬B)`**
+- `¬p` (p atomic) ⇒ stays `¬p`
+
+**Constant / idempotency simplification**
+- `and`: `false ∧ _` ⇒ `false`; `_ ∧ false` ⇒ `false`; `true ∧ X` ⇒ `X`; `X ∧ true` ⇒ `X`;
+  `X ∧ X` ⇒ `X`; `X ∧ ¬X` ⇒ `false`
+- `or`: `true ∨ _` ⇒ `true`; `_ ∨ true` ⇒ `true`; `false ∨ X` ⇒ `X`; `X ∨ false` ⇒ `X`;
+  `X ∨ X` ⇒ `X`; `X ∨ ¬X` ⇒ `true`
+- `next`: `X(true)` ⇒ `true`; `X(false)` ⇒ `false`
+- `eventually`: `F(true)` ⇒ `true`; `F(false)` ⇒ `false`; `F(F A)` ⇒ `F A`
+- `globally`: `G(true)` ⇒ `true`; `G(false)` ⇒ `false`; `G(G A)` ⇒ `G A`
+- `until`: `A U true` ⇒ `true`; `A U false` ⇒ `false`; `false U B` ⇒ `B`
+- `weakUntil`: `A W true` ⇒ `true`; `A W false` ⇒ `G A`; `false W B` ⇒ `B`
+- `release`: `false R B` ⇒ `G B`; `true R B` ⇒ `B`; `A R false` ⇒ `false`; `A R true` ⇒ `true`
+
+Worked examples (all verified to pass):
+```swift
+F.not(.until(p, q)).normalized()  == .release(.and(.not(p), .not(q)), .not(q))
+F.not(.release(p, q)).normalized() == .until(.not(q), .and(.not(p), .not(q)))
+F.weakUntil(p, .booleanLiteral(false)).normalized() == .globally(p)
+F.not(.implies(p, q)).normalized() == .and(p, .not(q))
+```
+
+When the exact form is uncertain, assert a **property** instead of an equality:
+```swift
+#expect(once.normalized() == once)                 // idempotent
+#expect(!containsImplication(f.normalized()))      // implications eliminated
+```
+
+## Model checking
+
+```swift
+public final class LTLModelChecker<Model: KripkeStructure> {
+    public init()
+    public func check<P: TemporalProposition>(formula: LTLFormula<P>, model: Model)
+        throws -> ModelCheckResult<Model.State>
+        where P.ID == Model.AtomicPropositionIdentifier, P.Value == Bool
+}
+
+public protocol KripkeStructure {
+    associatedtype State: Hashable
+    associatedtype AtomicPropositionIdentifier: Hashable     // use PropositionID
+    var allStates: Set<State> { get }
+    var initialStates: Set<State> { get }
+    func successors(of state: State) -> Set<State>
+    func atomicPropositionsTrue(in state: State) -> Set<AtomicPropositionIdentifier>
+}
+
+public enum ModelCheckResult<State: Hashable> {
+    case holds
+    case fails(counterexample: Counterexample<State>)   // .holds is a CASE, do not add a `var holds`
+}
+public struct Counterexample<State: Hashable> {
+    public let prefix: [State]   // lasso prefix
+    public let cycle: [State]    // repeating cycle
+}
+```
+
+**Key semantic fact:** for *model checking*, whether an atom holds in a state is
+decided by `model.atomicPropositionsTrue(in:)` (the labeling), matched against
+`prop.id`. The proposition's `evaluate` closure is ignored here — make it a dummy
+`{ _ in true }`. (In contrast, *trace evaluation* via `LTLFormula.evaluate`/
+`LTLFormulaTraceEvaluator` DOES use the closure.)
+
+Minimal model-checking test skeleton:
+```swift
+struct M: KripkeStructure {
+    typealias State = Int
+    typealias AtomicPropositionIdentifier = PropositionID
+    let allStates: Set<Int>; let initialStates: Set<Int>
+    let edges: [Int: Set<Int>]; let pTrue: Set<Int>; let pID: PropositionID
+    func successors(of s: Int) -> Set<Int> { edges[s] ?? [] }
+    func atomicPropositionsTrue(in s: Int) -> Set<PropositionID> { pTrue.contains(s) ? [pID] : [] }
+}
+let p = TemporalKit.makeProposition(id: "p", name: "p") { (_: Int) in true }
+let gp: LTLFormula<ClosureTemporalProposition<Int, Bool>> = .globally(.atomic(p))
+let result = try LTLModelChecker<M>().check(formula: gp, model: m)
+// switch on result { case .holds / case .fails(let cex): cex.prefix, cex.cycle }
+```
+
+## DSL operators (optional, for readability)
+`!` (not) · `&&` (and) · `||` (or) · `==>` (implies) · `~>>` (until) ·
+`~~>` (weakUntil) · `~<` (release) · `LTLFormula.X/.F/.G(_)` ·
+methods `.until/.weakUntil/.release/.implies(_)`.


### PR DESCRIPTION
## 概要
ソースを読まずに TemporalKit のテストを速記するための**参照スキル** `skills/temporalkit-tests/` を追加します。素のモデルが記憶だけで書くと誤りやすい、TemporalKit 固有の事実を集約したリファレンスです。

## 中身（測定された残差を埋める内容のみ）
- **`normalized()` の正確な NNF 書き換え表** — 例: `¬(A U B)` → `(¬A∧¬B) R ¬B`（教科書の `¬A R ¬B` ではない）、`¬(A R B)`/`¬(A W B)` → `¬B U (¬A∧¬B)`、定数畳み込み（`A W false` → `G A` 等）
- **`PropositionID` の構築** — `RawRepresentable`（文字列リテラル不可）、`makeProposition(id: String)`、ラベリングは `prop.id`
- **ディレクトリ別のテストフレームワーク** — `ModelChecking/` は XCTest、それ以外は swift-testing（編集対象ファイルに合わせる、を両面で明記）
- **Linux Swift 6.0 CI ゲート**（トレーリングカンマ・`throws:` 内ネスト `#expect` を回避）

## 作り方（Residual Skill Engineering）
「想像」ではなく**実測**で、素のモデルが*失敗する点だけ*を encode しています。

ソース未読・held-out 条件のアブレーション（実コンパイル＆実行で採点）:

| 条件 | 合格率 | bias-trap（XCTest 維持） |
|---|---|---|
| naive（スキルなし） | 1/4 | — |
| sham（長さ一致のダミー） | 0/4 | — |
| **skill** | **4/4** | **回帰なし** |

skill は naive・sham の両方に勝ち、誤発火もないため採択しました（sham ≤ naive なので効果はトークン量でなく中身）。なおソースを読める経路では素のモデルでも通るため、この残差は **no-source / 速記経路に限定**されます。モデル更新時は再計測してください。

## 配置に関する注意
`skills/`（リポジトリ直下）は**閲覧・参照用**で、Claude Code は自動ロードしません（自動ロードは `.claude/skills/` のみ）。各自の環境で有効化したい場合は `.claude/skills/temporalkit-tests` へのシンボリックリンク等で対応できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * TemporalKit の LTL テスト作成手順を新規追加し、必要な構成、期待値の作り方、推奨テストフレームワークの使い分けを整理しました。
  * 主要な API とセマンティクス、`normalized()` の変換ルール、原子命題の扱い、モデルチェック時の注意点をまとめました。
  * Linux CI と Swift 6.0 に関する制約も追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->